### PR TITLE
Don't run coverage job with MSRV toolchain

### DIFF
--- a/template/.github/workflows/ci.yml
+++ b/template/.github/workflows/ci.yml
@@ -41,7 +41,6 @@ jobs:
       matrix:
         rust:
           - stable
-          - {{ rust-version }} # MSRV
         os:
           - ubuntu-latest
           - macos-latest


### PR DESCRIPTION
cargo llvm-cov works on Rust 1.60.0+