### PR TITLE
Remove version sync

### DIFF
--- a/template/Cargo.toml
+++ b/template/Cargo.toml
@@ -20,7 +20,6 @@ categories = []
 
 [dev-dependencies]
 {% if crate_type == "lib" -%}
-version-sync = "0.9.4"
 cargo-readme = "3.2.0"
 {% endif %}
 [build-dependencies]

--- a/template/README.md
+++ b/template/README.md
@@ -17,7 +17,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-{{ project-name }} = "0.1.0-alpha.0"
+{{ project-name }} = "0.1.0"
 ```
 
 {%- else -%}

--- a/template/src/lib.rs
+++ b/template/src/lib.rs
@@ -7,10 +7,10 @@
 //!
 //! ```toml
 //! [dependencies]
-//! {{ project-name }} = "0.1.0-alpha.0"
+//! {{ project-name }} = "0.1.0"
 //! ```
 
-#![doc(html_root_url = "https://docs.rs/{{project-name}}/0.1.0-alpha.0")]
+#![doc(html_root_url = "https://docs.rs/{{project-name}}/0.1.0")]
 
 {% endif -%}
 

--- a/template/tests/version_number.rs
+++ b/template/tests/version_number.rs
@@ -1,9 +1,0 @@
-#[test]
-fn test_readme_deps() {
-    version_sync::assert_markdown_deps_updated!("README.md");
-}
-
-#[test]
-fn test_html_root_url() {
-    version_sync::assert_html_root_url_updated!("src/lib.rs");
-}


### PR DESCRIPTION
When specifying a pre-release version in Cargo.toml, version-sync causes an invalid version to be displayed in the README.
Update the version number on release by cargo-release to replace the check by version-sync.