### PR TITLE
release.toml: remove dev-version

### DIFF
--- a/template/release.toml
+++ b/template/release.toml
@@ -12,4 +12,3 @@ pre-release-replacements = [
   {file = "src/lib.rs", search = "^#!\\[doc\\(html_root_url = \"https://docs.rs/{{ project-name }}/.*\"\\)\\]$", replace = "#![doc(html_root_url = \"https://docs.rs/{{ project-name }}/{{ '{{version}}' }}\")]", exactly = 1},
 ]
 pre-release-hook = ["cargo", "xtask", "pre-release"]
-dev-version = true


### PR DESCRIPTION
cargo-release removed dev-version support

https://github.com/crate-ci/cargo-release/releases/tag/v0.22.0