### PR TITLE
Bump clap and cli-xtask

### DIFF
--- a/template/Cargo.toml
+++ b/template/Cargo.toml
@@ -34,7 +34,7 @@ pkg-fmt = "tgz"
 {% endif %}
 [dependencies]
 {% if crate_type == "bin" -%}
-clap = { version = "4.5", features = ["derive"] }
+clap = { version = "4.6", features = ["derive"] }
 {% endif %}
 [dev-dependencies]
 [build-dependencies]

--- a/template/xtask/Cargo.toml
+++ b/template/xtask/Cargo.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cli-xtask = { version = "0.8", features = ["{{ crate_type }}-crate", "{{ crate_type }}-crate-extra", "main"] }
+cli-xtask = { version = "0.10", features = ["{{ crate_type }}-crate", "{{ crate_type }}-crate-extra", "main"] }
 {% if crate_type == "bin" -%}
 {{ project-name }} = { path = ".." }
 {%- endif %}


### PR DESCRIPTION
## Summary
- Bump `clap` to 4.6 for the bin template
- Bump `cli-xtask` to 0.10 for xtask

## Testing
- Not run (template-only change)