### PR TITLE
chore(template): group cargo dependabot updates for patch releases

### DIFF
--- a/template/.github/dependabot.yml
+++ b/template/.github/dependabot.yml
@@ -6,5 +6,11 @@ updates:
       interval: "weekly"
   - package-ecosystem: "cargo"
     directory: "/"
+    allow:
+      - dependency-type: "all"
     schedule:
       interval: "weekly"
+    groups:
+      patch-only:
+        update-types:
+          - "patch"


### PR DESCRIPTION
## Summary
- update Dependabot config under template: `template/.github/dependabot.yml`
- allow cargo updates for all dependency types
- group cargo updates so patch releases are grouped into a single PR

## Notes
- this change targets the template's Dependabot configuration, not the root repository configuration