### PR TITLE
chore(template): split cargo dependabot groups by dependency type

### DIFF
--- a/template/.github/dependabot.yml
+++ b/template/.github/dependabot.yml
@@ -11,6 +11,13 @@ updates:
     schedule:
       interval: "weekly"
     groups:
-      patch-only:
+      cargo-transitive:
+        dependency-type: "indirect"
+        patterns:
+          - "*"
+      cargo-direct-patch:
+        dependency-type: "direct"
         update-types:
           - "patch"
+        patterns:
+          - "*"


### PR DESCRIPTION
Update `template/.github/dependabot.yml` to use clearer cargo Dependabot group identifiers and grouping strategy. Changes: replace patch-only with cargo-transitive (indirect dependencies grouped together) and cargo-direct-patch (direct patch updates grouped). This affects the template configuration only.