### PR TITLE
revert: undo invalid cargo Dependabot group dependency-type config

### DIFF
--- a/template/.github/dependabot.yml
+++ b/template/.github/dependabot.yml
@@ -11,13 +11,6 @@ updates:
     schedule:
       interval: "weekly"
     groups:
-      cargo-transitive:
-        dependency-type: "indirect"
-        patterns:
-          - "*"
-      cargo-direct-patch:
-        dependency-type: "direct"
+      patch-only:
         update-types:
           - "patch"
-        patterns:
-          - "*"

--- a/template/.github/dependabot.yml
+++ b/template/.github/dependabot.yml
@@ -11,6 +11,6 @@ updates:
     schedule:
       interval: "weekly"
     groups:
-      patch-only:
+      cargo-patch:
         update-types:
           - "patch"


### PR DESCRIPTION
This reverts PR #87.

Reason: groups.<identifier>.dependency-type only supports development/production, so using direct/indirect in group rules is invalid.

Result: restore template/.github/dependabot.yml to the previous valid configuration.