### PR TITLE
ci: add concurrency settings to cancel outdated workflow runs

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -9,6 +9,10 @@ on:
     # Runs at 00:00 UTC everyday
     - cron: "0 0 * * *"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.ref_name != github.event.repository.default_branch }}
+
 jobs:
   synchronize_example:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.ref_name != github.event.repository.default_branch }}
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/template/.github/workflows/audit.yml
+++ b/template/.github/workflows/audit.yml
@@ -10,6 +10,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: {{ "${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}" }}
+  cancel-in-progress: {{ "${{ github.ref_name != github.event.repository.default_branch }}" }}
+
 jobs:
   audit:
     uses: gifnksm/rust-template/.github/workflows/reusable-audit.yml@main

--- a/template/.github/workflows/cd.yml
+++ b/template/.github/workflows/cd.yml
@@ -9,6 +9,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: {{ "${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}" }}
+  cancel-in-progress: {{ "${{ github.ref_name != github.event.repository.default_branch }}" }}
+
 jobs:
   cd:
     uses: gifnksm/rust-template/.github/workflows/reusable-cd.yml@main

--- a/template/.github/workflows/ci.yml
+++ b/template/.github/workflows/ci.yml
@@ -7,6 +7,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: {{ "${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}" }}
+  cancel-in-progress: {{ "${{ github.ref_name != github.event.repository.default_branch }}" }}
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
## Summary

Add `concurrency` settings to all non-reusable workflow files to automatically cancel outdated runs when new pushes or pull request updates occur.

## Changes

- `.github/workflows/ci.yml`
- `.github/workflows/cd.yml`
- `template/.github/workflows/ci.yml`
- `template/.github/workflows/cd.yml`
- `template/.github/workflows/audit.yml`

`reusable-*.yml` workflows are excluded since they are called via `workflow_call` and inherit concurrency settings from the caller.

## Behavior

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
  cancel-in-progress: ${{ github.ref_name != github.event.repository.default_branch }}
```

- **PR / feature branch push** → cancels older in-progress runs in the same group
- **Default branch (main) push** → does NOT cancel (`cancel-in-progress: false`)