### PR TITLE
ci: unify GITHUB_TOKEN permissions across workflows

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -13,6 +13,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.ref_name != github.event.repository.default_branch }}
 
+permissions: {}
+
 jobs:
   synchronize_example:
     runs-on: ubuntu-latest
@@ -103,7 +105,6 @@ jobs:
       - synchronize_example
     runs-on: ubuntu-latest
     if: ${{ always() }}
-    permissions: {}
     steps:
       - name: CD complete
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.ref_name != github.event.repository.default_branch }}
 
+permissions: {}
+
 jobs:
   build:
     name: Build
@@ -79,7 +81,6 @@ jobs:
       - markdownlint
     runs-on: ubuntu-latest
     if: ${{ always() }}
-    permissions: {}
     steps:
       - name: CI complete
         run: |

--- a/.github/workflows/reusable-audit.yml
+++ b/.github/workflows/reusable-audit.yml
@@ -4,6 +4,8 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+permissions: {}
+
 jobs:
   security_audit:
     name: Security Audit

--- a/.github/workflows/reusable-cd.yml
+++ b/.github/workflows/reusable-cd.yml
@@ -12,6 +12,8 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+permissions: {}
+
 jobs:
   release:
     name: Publishing for ${{ matrix.job.target }}

--- a/.github/workflows/reusable-ci.yml
+++ b/.github/workflows/reusable-ci.yml
@@ -43,6 +43,8 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+permissions: {}
+
 jobs:
   set-matrix:
     runs-on: ubuntu-latest

--- a/template/.github/workflows/audit.yml
+++ b/template/.github/workflows/audit.yml
@@ -17,6 +17,8 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
 
+permissions: {}
+
 jobs:
   security-audit:
     name: Security Audit
@@ -50,7 +52,6 @@ jobs:
       - cargo-deny
     runs-on: ubuntu-latest
     if: ${{ always() }}
-    permissions: {}
     steps:
       - name: Audit complete
         run: |

--- a/template/.github/workflows/bin-cd.yml
+++ b/template/.github/workflows/bin-cd.yml
@@ -16,6 +16,8 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
 
+permissions: {}
+
 jobs:
   release:
     name: Publishing for ${{ matrix.job.target }}
@@ -82,7 +84,6 @@ jobs:
       - release
     runs-on: ubuntu-latest
     if: ${{ always() }}
-    permissions: {}
     steps:
       - name: CD complete
         run: |

--- a/template/.github/workflows/ci.yml
+++ b/template/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
 
+permissions: {}
+
 jobs:
   set-matrix:
     runs-on: ubuntu-latest
@@ -308,7 +310,6 @@ jobs:
       - markdownlint
     runs-on: ubuntu-latest
     if: ${{ always() }}
-    permissions: {}
     steps:
       - name: CI complete
         run: |

--- a/template/.github/workflows/update-deps.yml
+++ b/template/.github/workflows/update-deps.yml
@@ -6,6 +6,8 @@ on:
     - cron: "0 0 * * 1"
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   update-deps:
     name: Update Dependencies


### PR DESCRIPTION
## Summary

Unify `permissions` declarations across all GitHub Actions workflows by:

1. Adding `permissions: {}` at the **workflow level** as a secure default in all workflows
2. Removing redundant `permissions: {}` from individual jobs that were only restating the default
3. Keeping explicit per-job overrides only where elevated permissions are actually needed

## Changes

### `.github/workflows/`
- `ci.yml`, `cd.yml`: Add workflow-level `permissions: {}`; remove redundant job-level `{}`
- `reusable-ci.yml`, `reusable-audit.yml`, `reusable-cd.yml`: Add workflow-level `permissions: {}`

### `template/.github/workflows/`
- `audit.yml`, `bin-cd.yml`, `ci.yml`, `update-deps.yml`: Add workflow-level `permissions: {}`; remove redundant job-level `{}`
- `lib-cd.yml`: Already correct, no changes needed

Jobs with explicit elevated permissions (unchanged):
- `reusable-cd.yml` / `release`: `contents: write`
- `reusable-audit.yml` / `security_audit`: `issues: write`
- `template/bin-cd.yml` / `release`: `contents: write`
- `template/audit.yml` / `security-audit`: `issues: write`
- `template/update-deps.yml` / `update-deps`: `contents: read`

Fixes CodeQL alerts: `actions/missing-workflow-permissions`