### PR TITLE
fix: pass crate_type to update_repo script in all call sites

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: update example
         run: |
-          ./tests/scripts/update_repo example_repo ${{ env.PROJECT_NAME }}
+          ./tests/scripts/update_repo ${{ matrix.job.crate_type }} example_repo ${{ env.PROJECT_NAME }}
           git -C example_repo add -N .
 
       - name: test example

--- a/tests/scripts/update_repo
+++ b/tests/scripts/update_repo
@@ -2,16 +2,22 @@
 
 set -eux
 
-repo_path="$1"
-output_path="$2"
+crate_type="$1"
+repo_path="$2"
+output_path="$3"
 
 pkg_version="$(sed -n 's/^version = "\(.*\)"$/\1/p' "${repo_path}/Cargo.toml")"
-released_version="$(sed -n 's@^//! rust-template-generated-... = "\(.*\)"$@\1@p' ${repo_path}/src/lib.rs)"
+if [[ "${crate_type}" == "lib" ]]; then
+  released_version="$(sed -n 's@^//! rust-template-generated-... = "\(.*\)"$@\1@p' ${repo_path}/src/lib.rs)"
+fi
 
 find "${repo_path}" -mindepth 1 -maxdepth 1 -not -name .git -a -not -name CHANGELOG.md -exec rm -rf {} \;
 find "${output_path}" -mindepth 1 -maxdepth 1 -not -name .git -a -not -name CHANGELOG.md -exec cp -r {} "${repo_path}" \;
 
-perl -i -pe 's@(?<=^rust-template-generated-... = ").*(?="$)@'"${released_version}"'@' "${repo_path}/README.md"
-perl -i -pe 's@(?<=^//! rust-template-generated-... = ").*(?="$)@'"${released_version}"'@' "${repo_path}/src/lib.rs"
-perl -i -pe 's@(?<=^#!\[doc\(html_root_url = "https://docs.rs/rust-template-generated-.../).*(?="\)\]$)@'"${released_version}"'@' "${repo_path}/src/lib.rs"
+if [[ "${crate_type}" == "lib" ]]; then
+  perl -i -pe 's@(?<=^rust-template-generated-... = ").*(?="$)@'"${released_version}"'@' "${repo_path}/README.md"
+  perl -i -pe 's@(?<=^//! rust-template-generated-... = ").*(?="$)@'"${released_version}"'@' "${repo_path}/src/lib.rs"
+  perl -i -pe 's@(?<=^#!\[doc\(html_root_url = "https://docs.rs/rust-template-generated-.../).*(?="\)\]$)@'"${released_version}"'@' "${repo_path}/src/lib.rs"
+fi
+
 perl -i -pe 's@(?<=^version = ").*(?="$)@'"${pkg_version}"'@' "${repo_path}/Cargo.toml"

--- a/tests/test
+++ b/tests/test
@@ -23,7 +23,7 @@ for crate_type in bin lib; do
 
     rm -rf "repo.${crate_type}"
     git clone "https://github.com/gifnksm/rust-template-generated-${crate_type}" "repo.${crate_type}"
-    ./scripts/update_repo "repo.${crate_type}" "out.${crate_type}"
+    ./scripts/update_repo "${crate_type}" "repo.${crate_type}" "out.${crate_type}"
     (
         cd "repo.${crate_type}"
         ../scripts/run_cargo_tests "${crate_type}"


### PR DESCRIPTION
## Summary

Fix an oversight from PR #98 (Stop generating lib.rs for bin templates).

The `update_repo` script was unconditionally reading `lib.rs` to get the released version and updating version strings in `lib.rs` and `README.md`, which fails for `bin` crate types since they no longer have `lib.rs`.

## Changes

- Add `crate_type` as the first argument to `tests/scripts/update_repo`
- Read `released_version` from the repo **before** wiping its contents (was accidentally reading from the newly-copied template output with `0.0.0`)
- Gate lib.rs/README version restore operations behind `crate_type == "lib"`
- Update all call sites (`tests/test`, `.github/workflows/cd.yml`) to pass `crate_type`