### PR TITLE
Run cargo-deny on stable toolchain

### DIFF
--- a/template/.github/workflows/audit.yml
+++ b/template/.github/workflows/audit.yml
@@ -38,6 +38,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - uses: EmbarkStudios/cargo-deny-action@v2
         with:
+          rust-version: stable
           command: check advisories
 
   cargo-deny-policy:
@@ -48,6 +49,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - uses: EmbarkStudios/cargo-deny-action@v2
         with:
+          rust-version: stable
           command: check bans licenses sources
 
   audit-complete:


### PR DESCRIPTION
## Summary
- run `cargo-deny-action` with the stable Rust toolchain
- apply the same toolchain setting to both advisory and policy checks

## Why
`cargo-deny-action@v2` otherwise uses the toolchain bundled in the action image. Setting `rust-version: stable` keeps the audit jobs running on a current stable toolchain explicitly.