### PR TITLE
Drop i686 Linux release target

### DIFF
--- a/template/.github/workflows/bin-cd.yml
+++ b/template/.github/workflows/bin-cd.yml
@@ -31,8 +31,6 @@ jobs:
             target: x86_64-unknown-linux-gnu
           - os: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
-          - os: ubuntu-latest
-            target: i686-unknown-linux-gnu
           - os: macos-latest
             target: aarch64-apple-darwin
           - os: windows-latest
@@ -44,9 +42,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: ${{ matrix.rust }}
-      - uses: taiki-e/install-action@v2
-        with:
-          tool: cross
       - uses: Swatinem/rust-cache@v2
         with:
           key: ${{ matrix.job.target }}


### PR DESCRIPTION
## Summary
- remove the `i686-unknown-linux-gnu` release target from `bin-cd.yml`
- stop installing `cross` in the release workflow
- keep `scripts/build-dist --target ...` behavior unchanged for manual use

## Why
The removed `i686` target was the only release matrix entry that required cross-compilation in CI. Dropping it lets generated binary projects build release artifacts on native runners without installing `cross`, which also avoids issues caused by `cross` lagging behind newer Cargo manifest behavior.

## Impact
- generated projects will no longer publish a 32-bit Linux release asset
- manual `./scripts/build-dist --target ...` usage is still left intact for future non-native targets

## Validation
- ran `actionlint template/.github/workflows/bin-cd.yml` locally