### PR TITLE
Bundle third-party license report

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: taiki-e/install-action@v2
         with:
-          tool: cargo-generate,just,cargo-hack,cargo-docs-rs,cargo-sync-rdme,cargo-machete,cargo-llvm-cov,typos
+          tool: cargo-generate,just,cargo-hack,cargo-docs-rs,cargo-sync-rdme,cargo-machete,cargo-llvm-cov,typos,cargo-about
       - name: Install actionlint
         run: bash <(curl -sSfL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash) && sudo mv actionlint /usr/local/bin/
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: taiki-e/install-action@v2
         with:
-          tool: cargo-generate,just,cargo-hack,cargo-docs-rs,cargo-sync-rdme,cargo-machete,cargo-llvm-cov,typos
+          tool: cargo-generate,just,cargo-hack,cargo-docs-rs,cargo-sync-rdme,cargo-machete,cargo-llvm-cov,typos,cargo-about
       - name: Install actionlint
         run: bash <(curl -sSfL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash) && sudo mv actionlint /usr/local/bin/
         shell: bash
@@ -91,4 +91,3 @@ jobs:
             exit 1
           fi
         shell: bash
-

--- a/template/.github/workflows/bin-cd.yml
+++ b/template/.github/workflows/bin-cd.yml
@@ -42,6 +42,9 @@ jobs:
       - uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: ${{ matrix.rust }}
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-about
       - uses: Swatinem/rust-cache@v2
         with:
           key: ${{ matrix.job.target }}

--- a/template/about.hbs
+++ b/template/about.hbs
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <title>Third Party Licenses</title>
+    <style>
+        @media (prefers-color-scheme: dark) {
+            body {
+                background: #333;
+                color: white;
+            }
+            a {
+                color: skyblue;
+            }
+        }
+        .container {
+            font-family: sans-serif;
+            max-width: 800px;
+            margin: 0 auto;
+        }
+        .intro {
+            text-align: center;
+        }
+        .licenses-list {
+            list-style-type: none;
+            margin: 0;
+            padding: 0;
+        }
+        .license-used-by {
+            margin-top: -10px;
+        }
+        .license-text {
+            max-height: 200px;
+            overflow-y: scroll;
+            white-space: pre-wrap;
+        }
+    </style>
+</head>
+
+<body>
+    <main class="container">
+        <div class="intro">
+            <h1>Third Party Licenses</h1>
+            <p>This page lists the licenses of third-party dependencies used by {{ project-name }}.</p>
+        </div>
+{%raw%}
+        <h2>Overview of licenses:</h2>
+        <ul class="licenses-overview">
+            {{#each overview}}
+            <li><a href="#{{id}}">{{name}}</a> ({{count}})</li>
+            {{/each}}
+        </ul>
+
+        <h2>All license text:</h2>
+        <ul class="licenses-list">
+            {{#each licenses}}
+            <li class="license">
+                <h3 id="{{id}}">{{name}}</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
+                    {{#each used_by}}
+                    <li><a href="{{#if crate.repository}}{{crate.repository}}{{else}}https://crates.io/crates/{{crate.name}}{{/if}}">{{crate.name}} {{crate.version}}</a></li>
+                    {{/each}}
+                </ul>
+                <pre class="license-text">{{text}}</pre>
+            </li>
+            {{/each}}
+        </ul>
+{%endraw%}
+    </main>
+</body>
+
+</html>

--- a/template/about.toml
+++ b/template/about.toml
@@ -1,0 +1,13 @@
+targets = [
+  "x86_64-unknown-linux-gnu",
+  "aarch64-unknown-linux-gnu",
+  "aarch64-apple-darwin",
+  "x86_64-pc-windows-msvc",
+  "aarch64-pc-windows-msvc",
+]
+accepted = [
+  "MIT",
+  "Apache-2.0",
+  "Unicode-3.0",
+]
+private = { ignore = true }

--- a/template/cargo-generate.toml
+++ b/template/cargo-generate.toml
@@ -5,7 +5,7 @@ post = ["post-script.rhai"]
 exclude = [".github/workflows/*.yml", "justfile.*"]
 
 [conditional.'crate_type == "lib"']
-ignore = [ "src/main.rs", "scripts/build-dist" ]
+ignore = [ "src/main.rs", "scripts/build-dist", "about.toml", "about.hbs" ]
 
 [conditional.'crate_type == "bin"']
 ignore = [ "src/lib.rs" ]

--- a/template/scripts/build-dist
+++ b/template/scripts/build-dist
@@ -162,6 +162,7 @@ main() {
 
     cp README.md "${BUILD_DIR}"
     cp LICENSE-* "${BUILD_DIR}"
+    cargo about generate about.hbs --output-file "${BUILD_DIR}/THIRD_PARTY_LICENSES.html" --target "${target_triple}"
 
     for pkg in "${DIST_PACKAGES[@]}"; do
         local -a bin_names=()


### PR DESCRIPTION
## Summary
- bundle a third-party license report into generated binary release archives
- add `cargo-about` setup and template files for bin crates
- generate `THIRD_PARTY_LICENSES.html` in `scripts/build-dist` with the requested `--target`
- exclude `about.hbs` and `about.toml` from generated lib crates

## Details
This updates the binary release workflow to install `cargo-about`, adds `about.toml` and an `about.hbs` template to the project template, and teaches `build-dist` to emit `THIRD_PARTY_LICENSES.html` alongside the existing release artifacts.

The `about.hbs` template keeps `cargo-generate` placeholders and `cargo-about` handlebars syntax from interfering with each other by wrapping the `cargo-about` sections in raw blocks.

`build-dist --target ...` now passes the same target triple through to `cargo about generate --target ...`, so the bundled license report matches the dependency set for the artifact being built.

## Validation
- ran `actionlint template/.github/workflows/bin-cd.yml`
- ran `cargo generate --name rust-template-generated-bin-review --path template --template-values-file tests/template_values.toml --bin --allow-commands`
- ran `cargo generate --name rust-template-generated-lib-review --path template --template-values-file tests/template_values.toml --lib --allow-commands`
- ran `cargo about generate rust-template-generated-bin-review/about.hbs --manifest-path rust-template-generated-bin-review/Cargo.toml --output-file rust-template-generated-bin-review/THIRD_PARTY_LICENSES-targeted.html --target x86_64-unknown-linux-gnu`

These checks confirmed that bin generation preserves the `cargo-about` handlebars, lib generation omits the `about.*` files, and the targeted license report is generated successfully.