### PR TITLE
Add editorconfig-checker lint

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,9 +9,9 @@ insert_final_newline = true
 trim_trailing_whitespace = true
 
 [*.rs]
-indent_size = 4
+indent_size = unset
 
-[*.toml]
+[*.{toml,json}]
 indent_size = 2
 
 [*.{yml,yaml}]
@@ -19,6 +19,10 @@ indent_size = 2
 
 [*.md]
 trim_trailing_whitespace = false
+indent_size = unset
 
 [Makefile]
 indent_style = tab
+
+[LICENSE*]
+indent_size = unset

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -32,6 +32,7 @@ jobs:
       - uses: taiki-e/install-action@v2
         with:
           tool: cargo-generate,just,cargo-hack,cargo-docs-rs,cargo-sync-rdme,cargo-machete,cargo-llvm-cov,typos,cargo-about
+      - uses: editorconfig-checker/action-editorconfig-checker@v2
       - name: Install actionlint
         run: bash <(curl -sSfL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash) && sudo mv actionlint /usr/local/bin/
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
       - uses: taiki-e/install-action@v2
         with:
           tool: cargo-generate,just,cargo-hack,cargo-docs-rs,cargo-sync-rdme,cargo-machete,cargo-llvm-cov,typos,cargo-about
+      - uses: editorconfig-checker/action-editorconfig-checker@v2
       - name: Install actionlint
         run: bash <(curl -sSfL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash) && sudo mv actionlint /usr/local/bin/
         shell: bash
@@ -73,12 +74,21 @@ jobs:
       - uses: actions/checkout@v7
       - run: npx markdownlint-cli .
 
+  editorconfig:
+    name: EditorConfig
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: editorconfig-checker/action-editorconfig-checker@v2
+      - run: editorconfig-checker -format github-actions
+
   ci-complete:
     needs:
       - build
       - actionlint
       - typos
       - markdownlint
+      - editorconfig
     runs-on: ubuntu-latest
     if: ${{ always() }}
     steps:

--- a/template/.editorconfig
+++ b/template/.editorconfig
@@ -9,9 +9,9 @@ insert_final_newline = true
 trim_trailing_whitespace = true
 
 [*.rs]
-indent_size = 4
+indent_size = unset
 
-[*.toml]
+[*.{toml,json}]
 indent_size = 2
 
 [*.{yml,yaml}]
@@ -19,6 +19,10 @@ indent_size = 2
 
 [*.md]
 trim_trailing_whitespace = false
+indent_size = unset
 
 [Makefile]
 indent_style = tab
+
+[LICENSE*]
+indent_size = unset

--- a/template/.github/workflows/bin-ci.yml
+++ b/template/.github/workflows/bin-ci.yml
@@ -271,6 +271,17 @@ jobs:
           tool: just
       - run: just ci-markdownlint
 
+  editorconfig:
+    name: EditorConfig
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: just
+      - uses: editorconfig-checker/action-editorconfig-checker@v2
+      - run: just ci-editorconfig -format github-actions
+
   ci-complete:
     needs:
       - set-matrix
@@ -286,6 +297,7 @@ jobs:
       - actionlint
       - typos
       - markdownlint
+      - editorconfig
     runs-on: ubuntu-latest
     if: ${{ always() }}
     steps:

--- a/template/.github/workflows/lib-ci.yml
+++ b/template/.github/workflows/lib-ci.yml
@@ -292,6 +292,17 @@ jobs:
           tool: just
       - run: just ci-markdownlint
 
+  editorconfig:
+    name: EditorConfig
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: just
+      - uses: editorconfig-checker/action-editorconfig-checker@v2
+      - run: just ci-editorconfig -format github-actions
+
   ci-complete:
     needs:
       - set-matrix
@@ -308,6 +319,7 @@ jobs:
       - actionlint
       - typos
       - markdownlint
+      - editorconfig
     runs-on: ubuntu-latest
     if: ${{ always() }}
     steps:

--- a/template/justfile.bin
+++ b/template/justfile.bin
@@ -74,8 +74,12 @@ typos *args:
 markdownlint *args:
     npx markdownlint-cli {{ args }} .
 
+# Check EditorConfig compliance.
+editorconfig *args:
+    editorconfig-checker {{ args }}
+
 # Run lint and static checks used for day-to-day local verification.
-ci-lint: ci-rustfmt ci-check ci-clippy ci-machete ci-actionlint ci-typos ci-markdownlint
+ci-lint: ci-rustfmt ci-check ci-clippy ci-machete ci-actionlint ci-typos ci-markdownlint ci-editorconfig
 
 # Run all CI-equivalent checks.
 ci: ci-lint ci-rustdoc ci-sync-rdme ci-test ci-coverage
@@ -116,6 +120,10 @@ ci-typos:
 # CI: lint markdown files.
 ci-markdownlint:
     just markdownlint
+
+# CI: check EditorConfig compliance.
+ci-editorconfig *args:
+    just editorconfig {{ args }}
 
 # CI: test suite.
 ci-test:

--- a/template/justfile.lib
+++ b/template/justfile.lib
@@ -78,8 +78,12 @@ typos *args:
 markdownlint *args:
     npx markdownlint-cli {{ args }} .
 
+# Check EditorConfig compliance.
+editorconfig *args:
+    editorconfig-checker {{ args }}
+
 # Run lint and static checks used for day-to-day local verification.
-ci-lint: ci-rustfmt ci-check ci-clippy ci-machete ci-actionlint ci-typos ci-markdownlint
+ci-lint: ci-rustfmt ci-check ci-clippy ci-machete ci-actionlint ci-typos ci-markdownlint ci-editorconfig
 
 # Run all CI-equivalent checks.
 ci: ci-lint ci-rustdoc ci-docs-rs ci-sync-rdme ci-test ci-coverage
@@ -125,6 +129,10 @@ ci-typos:
 # CI: lint markdown files.
 ci-markdownlint:
     just markdownlint
+
+# CI: check EditorConfig compliance.
+ci-editorconfig *args:
+    just editorconfig {{ args }}
 
 # CI: test suite.
 ci-test:

--- a/template/post-script.rhai
+++ b/template/post-script.rhai
@@ -1,21 +1,21 @@
 let crate_type = variable::get("crate_type");
 
 if crate_type == "bin" {
-  file::rename(".github/workflows/bin-ci.yml", ".github/workflows/ci.yml");
-  file::delete(".github/workflows/lib-ci.yml");
-  file::rename(".github/workflows/bin-cd.yml", ".github/workflows/cd.yml");
-  file::delete(".github/workflows/lib-cd.yml");
-  file::rename("justfile.bin", "justfile");
-  file::delete("justfile.lib");
+    file::rename(".github/workflows/bin-ci.yml", ".github/workflows/ci.yml");
+    file::delete(".github/workflows/lib-ci.yml");
+    file::rename(".github/workflows/bin-cd.yml", ".github/workflows/cd.yml");
+    file::delete(".github/workflows/lib-cd.yml");
+    file::rename("justfile.bin", "justfile");
+    file::delete("justfile.lib");
 } else if crate_type == "lib" {
-  file::rename(".github/workflows/lib-ci.yml", ".github/workflows/ci.yml");
-  file::delete(".github/workflows/bin-ci.yml");
-  file::rename(".github/workflows/lib-cd.yml", ".github/workflows/cd.yml");
-  file::delete(".github/workflows/bin-cd.yml");
-  file::rename("justfile.lib", "justfile");
-  file::delete("justfile.bin");
+    file::rename(".github/workflows/lib-ci.yml", ".github/workflows/ci.yml");
+    file::delete(".github/workflows/bin-ci.yml");
+    file::rename(".github/workflows/lib-cd.yml", ".github/workflows/cd.yml");
+    file::delete(".github/workflows/bin-cd.yml");
+    file::rename("justfile.lib", "justfile");
+    file::delete("justfile.bin");
 } else {
-  abort("unknown crate_type");
+    abort("unknown crate_type");
 }
 
 system::command("just", ["sync-rdme-all", "--allow-dirty", "--allow-no-vcs"])

--- a/tests/scripts/run_cargo_tests
+++ b/tests/scripts/run_cargo_tests
@@ -3,20 +3,20 @@
 set -eux
 
 if [[ "$#" -ne 1 ]]; then
-  echo "Usage: $0 <crate_type>" >&2
-  exit 1
+    echo "Usage: $0 <crate_type>" >&2
+    exit 1
 fi
 
 crate_type="$1"
 case "${crate_type}" in
 bin | lib) ;;
 *)
-  echo "Invalid crate_type: ${crate_type}" >&2
-  exit 1
-  ;;
+    echo "Invalid crate_type: ${crate_type}" >&2
+    exit 1
+    ;;
 esac
 
 just ci
 if [[ "${crate_type}" == "bin" ]]; then
-  ./scripts/build-dist
+    ./scripts/build-dist
 fi

--- a/tests/scripts/update_repo
+++ b/tests/scripts/update_repo
@@ -8,16 +8,16 @@ output_path="$3"
 
 pkg_version="$(sed -n 's/^version = "\(.*\)"$/\1/p' "${repo_path}/Cargo.toml")"
 if [[ "${crate_type}" == "lib" ]]; then
-  released_version="$(sed -n 's@^//! rust-template-generated-... = "\(.*\)"$@\1@p' ${repo_path}/src/lib.rs)"
+    released_version="$(sed -n 's@^//! rust-template-generated-... = "\(.*\)"$@\1@p' "${repo_path}/src/lib.rs")"
 fi
 
 find "${repo_path}" -mindepth 1 -maxdepth 1 -not -name .git -a -not -name CHANGELOG.md -exec rm -rf {} \;
 find "${output_path}" -mindepth 1 -maxdepth 1 -not -name .git -a -not -name CHANGELOG.md -exec cp -r {} "${repo_path}" \;
 
 if [[ "${crate_type}" == "lib" ]]; then
-  perl -i -pe 's@(?<=^rust-template-generated-... = ").*(?="$)@'"${released_version}"'@' "${repo_path}/README.md"
-  perl -i -pe 's@(?<=^//! rust-template-generated-... = ").*(?="$)@'"${released_version}"'@' "${repo_path}/src/lib.rs"
-  perl -i -pe 's@(?<=^#!\[doc\(html_root_url = "https://docs.rs/rust-template-generated-.../).*(?="\)\]$)@'"${released_version}"'@' "${repo_path}/src/lib.rs"
+    perl -i -pe 's@(?<=^rust-template-generated-... = ").*(?="$)@'"${released_version}"'@' "${repo_path}/README.md"
+    perl -i -pe 's@(?<=^//! rust-template-generated-... = ").*(?="$)@'"${released_version}"'@' "${repo_path}/src/lib.rs"
+    perl -i -pe 's@(?<=^#!\[doc\(html_root_url = "https://docs.rs/rust-template-generated-.../).*(?="\)\]$)@'"${released_version}"'@' "${repo_path}/src/lib.rs"
 fi
 
 perl -i -pe 's@(?<=^version = ").*(?="$)@'"${pkg_version}"'@' "${repo_path}/Cargo.toml"


### PR DESCRIPTION
## Summary
- add `editorconfig-checker` lint jobs to the root CI workflow and generated bin/lib CI workflows
- add `editorconfig` and `ci-editorconfig` tasks to generated justfiles
- update `.editorconfig` settings and normalize affected files to match the enforced style

## Details
This adds an `EditorConfig` job to the repository CI and to the generated project CI workflows. Generated projects run the check through `just ci-editorconfig -format github-actions`, while the root repository workflow invokes `editorconfig-checker` directly after setting up the action.

The root repository's template verification workflows also need to set up `editorconfig-checker`, because they run generated projects' `just ci` through `tests/scripts/run_cargo_tests`, which now includes `ci-editorconfig`.

To keep the new lint green, the patch also updates `.editorconfig` / `template/.editorconfig` and reformats the affected Rhai and shell scripts to use the configured indentation and newline rules.

## Validation
- ran `actionlint .github/workflows/ci.yml`
- ran `actionlint template/.github/workflows/bin-ci.yml`
- ran `actionlint template/.github/workflows/lib-ci.yml`
- reviewed the `editorconfig-checker` action usage to confirm no extra binary installation is needed beyond `editorconfig-checker/action-editorconfig-checker@v2`